### PR TITLE
Clean up CIDS teardown temp mounts, networks, and volumes

### DIFF
--- a/backend/core/app/models/ids_system.py
+++ b/backend/core/app/models/ids_system.py
@@ -4,6 +4,7 @@ IDS System Models - Polymorphic base class and subclasses for NIDS, HIDS, CIDS.
 
 import asyncio
 import os
+import shutil
 import docker
 import httpx
 from http.client import HTTPResponse
@@ -25,6 +26,76 @@ from app.database import Base
 from app.logger import LOGGER
 from sqlalchemy.future import select
 from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def _remove_work_dir(host_system, work_dir):
+    """Best-effort cleanup of temporary CIDS work directories on local/remote Docker hosts."""
+    if not work_dir.startswith("/tmp/bicep_cids_"):
+        LOGGER.warning(f"Skipping work dir cleanup for unexpected path: {work_dir}")
+        return
+
+    host = (host_system.host or "").strip().lower()
+    is_local = host in {"", "localhost", "127.0.0.1"}
+
+    if is_local:
+        shutil.rmtree(work_dir, ignore_errors=True)
+        LOGGER.info(f"Removed local CIDS temp directory: {work_dir}")
+        return
+
+    host_ip, docker_port = host_system.get_host_and_docker_port()
+    docker_host_url = f"tcp://{host_ip}:{docker_port}"
+    docker_client = docker.DockerClient(base_url=docker_host_url)
+    relative_path = os.path.relpath(work_dir, "/tmp")
+
+    tmp_container = None
+    try:
+        tmp_container = docker_client.containers.run(
+            "alpine:3.19",
+            command=["sh", "-c", "rm -rf -- \"$TARGET_PATH\""],
+            environment={"TARGET_PATH": f"/host_tmp/{relative_path}"},
+            detach=True,
+            volumes={"/tmp": {"bind": "/host_tmp", "mode": "rw"}},
+        )
+        tmp_container.wait(timeout=20)
+        LOGGER.info(f"Removed remote CIDS temp directory: {work_dir}")
+    except Exception as exc:
+        LOGGER.warning(f"Failed to remove remote CIDS temp directory {work_dir}: {exc}")
+    finally:
+        try:
+            if tmp_container:
+                tmp_container.remove(force=True)
+        except Exception:
+            pass
+        docker_client.close()
+
+
+def _cleanup_project_networks_and_volumes(docker_host_url, project_name):
+    """Best-effort cleanup of leftover compose resources for a CIDS project."""
+    docker_client = docker.DockerClient(base_url=docker_host_url)
+    compose_label = f"com.docker.compose.project={project_name}"
+    try:
+        leftover_containers = docker_client.containers.list(
+            all=True, filters={"label": compose_label}
+        )
+        for container in leftover_containers:
+            try:
+                container.remove(force=True, v=True)
+            except Exception as exc:
+                LOGGER.warning(f"Failed removing leftover container {container.name}: {exc}")
+
+        for network in docker_client.networks.list(filters={"label": compose_label}):
+            try:
+                network.remove()
+            except Exception as exc:
+                LOGGER.warning(f"Failed removing network {network.name}: {exc}")
+
+        for volume in docker_client.volumes.list(filters={"label": compose_label}):
+            try:
+                volume.remove(force=True)
+            except Exception as exc:
+                LOGGER.warning(f"Failed removing volume {volume.name}: {exc}")
+    finally:
+        docker_client.close()
 
 
 class IdsSystem(Base):
@@ -353,6 +424,7 @@ class CidsSystem(IdsSystem):
             host_system = components[0].host_system
             host_name_safe = host_system.name.replace(" ", "_").lower()
             project_name = f"bicep_cids_{self.id}_{host_name_safe}"
+            work_dir = f"/tmp/{project_name}"
 
             host_ip, docker_port = host_system.get_host_and_docker_port()
             docker_host_url = f"tcp://{host_ip}:{docker_port}"
@@ -388,6 +460,14 @@ class CidsSystem(IdsSystem):
                     docker_client.close()
             except Exception as e:
                 LOGGER.error(f"Teardown error on {host_system.name}: {e}")
+            finally:
+                try:
+                    _cleanup_project_networks_and_volumes(docker_host_url, project_name)
+                except Exception as cleanup_exc:
+                    LOGGER.warning(
+                        f"Resource cleanup failed for {project_name} on {host_system.name}: {cleanup_exc}"
+                    )
+                _remove_work_dir(host_system, work_dir)
 
             for component in components:
                 await db.delete(component)

--- a/backend/core/app/models/ids_system.py
+++ b/backend/core/app/models/ids_system.py
@@ -30,22 +30,32 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 def _remove_work_dir(host_system, work_dir):
     """Best-effort cleanup of temporary CIDS work directories on local/remote Docker hosts."""
-    if not work_dir.startswith("/tmp/bicep_cids_"):
-        LOGGER.warning(f"Skipping work dir cleanup for unexpected path: {work_dir}")
+    normalized_work_dir = os.path.realpath(work_dir)
+    tmp_root = "/tmp"
+    expected_name_prefix = "bicep_cids_"
+
+    if (
+        os.path.commonpath([normalized_work_dir, tmp_root]) != tmp_root
+        or not os.path.basename(normalized_work_dir).startswith(expected_name_prefix)
+    ):
+        LOGGER.warning(
+            "Skipping work dir cleanup for unexpected path: "
+            f"{work_dir} (normalized: {normalized_work_dir})"
+        )
         return
 
     host = (host_system.host or "").strip().lower()
     is_local = host in {"", "localhost", "127.0.0.1"}
 
     if is_local:
-        shutil.rmtree(work_dir, ignore_errors=True)
-        LOGGER.info(f"Removed local CIDS temp directory: {work_dir}")
+        shutil.rmtree(normalized_work_dir, ignore_errors=True)
+        LOGGER.info(f"Removed local CIDS temp directory: {normalized_work_dir}")
         return
 
     host_ip, docker_port = host_system.get_host_and_docker_port()
     docker_host_url = f"tcp://{host_ip}:{docker_port}"
     docker_client = docker.DockerClient(base_url=docker_host_url)
-    relative_path = os.path.relpath(work_dir, "/tmp")
+    relative_path = os.path.relpath(normalized_work_dir, "/tmp")
 
     tmp_container = None
     try:
@@ -57,7 +67,7 @@ def _remove_work_dir(host_system, work_dir):
             volumes={"/tmp": {"bind": "/host_tmp", "mode": "rw"}},
         )
         tmp_container.wait(timeout=20)
-        LOGGER.info(f"Removed remote CIDS temp directory: {work_dir}")
+        LOGGER.info(f"Removed remote CIDS temp directory: {normalized_work_dir}")
     except Exception as exc:
         LOGGER.warning(f"Failed to remove remote CIDS temp directory {work_dir}: {exc}")
     finally:

--- a/backend/core/app/test/models/test_cids_teardown_cleanup.py
+++ b/backend/core/app/test/models/test_cids_teardown_cleanup.py
@@ -1,0 +1,38 @@
+from unittest.mock import MagicMock, patch
+
+from app.models.ids_system import (
+    _cleanup_project_networks_and_volumes,
+    _remove_work_dir,
+)
+
+
+def test_remove_work_dir_local_uses_shutil():
+    host = MagicMock()
+    host.host = "localhost"
+
+    with patch("app.models.ids_system.shutil.rmtree") as mock_rmtree:
+        _remove_work_dir(host, "/tmp/bicep_cids_7_localhost")
+
+    mock_rmtree.assert_called_once_with("/tmp/bicep_cids_7_localhost", ignore_errors=True)
+
+
+def test_cleanup_project_networks_and_volumes_removes_labeled_resources():
+    mock_client = MagicMock()
+    mock_container = MagicMock()
+    mock_container.name = "leftover-container"
+    mock_network = MagicMock()
+    mock_network.name = "leftover-network"
+    mock_volume = MagicMock()
+    mock_volume.name = "leftover-volume"
+
+    mock_client.containers.list.return_value = [mock_container]
+    mock_client.networks.list.return_value = [mock_network]
+    mock_client.volumes.list.return_value = [mock_volume]
+
+    with patch("app.models.ids_system.docker.DockerClient", return_value=mock_client):
+        _cleanup_project_networks_and_volumes("tcp://127.0.0.1:2375", "bicep_cids_7_localhost")
+
+    mock_container.remove.assert_called_once_with(force=True, v=True)
+    mock_network.remove.assert_called_once()
+    mock_volume.remove.assert_called_once_with(force=True)
+    mock_client.close.assert_called_once()

--- a/backend/core/app/test/models/test_cids_teardown_cleanup.py
+++ b/backend/core/app/test/models/test_cids_teardown_cleanup.py
@@ -16,6 +16,16 @@ def test_remove_work_dir_local_uses_shutil():
     mock_rmtree.assert_called_once_with("/tmp/bicep_cids_7_localhost", ignore_errors=True)
 
 
+def test_remove_work_dir_skips_path_traversal_outside_tmp():
+    host = MagicMock()
+    host.host = "localhost"
+
+    with patch("app.models.ids_system.shutil.rmtree") as mock_rmtree:
+        _remove_work_dir(host, "/tmp/bicep_cids_7_localhost/../../etc")
+
+    mock_rmtree.assert_not_called()
+
+
 def test_cleanup_project_networks_and_volumes_removes_labeled_resources():
     mock_client = MagicMock()
     mock_container = MagicMock()


### PR DESCRIPTION
### Motivation
- CIDS teardown left temporary mount directories under `/tmp/bicep_cids_*` and could leave Docker Compose networks/volumes/containers behind, causing resource leak and confusion. 
- The goal is to ensure teardown removes those temporary host directories and any compose-created networks/volumes for the CIDS project on both local and remote Docker hosts. 

### Description
- Added `_remove_work_dir(host_system, work_dir)` in `backend/core/app/models/ids_system.py` to remove `/tmp/bicep_cids_*` directories locally via `shutil.rmtree` and remotely by running a short-lived helper container that deletes the path from the host ` /tmp` bind mount, with a safety prefix check. 
- Added `_cleanup_project_networks_and_volumes(docker_host_url, project_name)` in `backend/core/app/models/ids_system.py` to best-effort remove leftover containers, networks, and volumes labeled with `com.docker.compose.project=<project_name>`. 
- Wired both helpers into `CidsSystem.teardown` so they always run in a `finally` block per host after attempting `compose down` (and after the existing fallback removal path), ensuring resources and temp dirs are cleaned even on errors. 
- Added unit tests `backend/core/app/test/models/test_cids_teardown_cleanup.py` that mock and verify local `shutil.rmtree` usage and removal of labeled containers/networks/volumes. 

### Testing
- Ran the new unit tests together with an existing CIDS reconfig test via `pytest -q backend/core/app/test/models/test_cids_teardown_cleanup.py backend/core/app/test/test_cids_reconfig.py`. 
- Test collection failed in this environment due to a missing import `ModuleNotFoundError: No module named 'app.bicep_utils.models'`, so automated tests could not complete here. 
- The new tests are isolated and exercise the two new helpers with mocked `docker.DockerClient` and `shutil`, and should pass when run in an environment where project imports resolve.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c675e7fc6883309c45c55030e1dfc7)