### PR TITLE
Feat: Use Unix socket for Docker daemon access (with TCP fallback)

### DIFF
--- a/backend/core/app/deployment/deployment_plugins/docker.py
+++ b/backend/core/app/deployment/deployment_plugins/docker.py
@@ -37,8 +37,12 @@ def _split_image_reference(image_reference: str) -> tuple[str, str | None]:
 
 
 def get_docker_client(host_system, timeout: int | None = None):
-    host, docker_port = host_system.get_host_and_docker_port()
-    host_url = f"tcp://{host}:{docker_port}"
+    if host_system.is_core_host():
+        socket_path = os.getenv("DOCKER_SOCKET_PATH", "/var/run/docker.sock")
+        host_url = f"unix://{socket_path}"
+    else:
+        host, docker_port = host_system.get_host_and_docker_port()
+        host_url = f"tcp://{host}:{docker_port}"
     try:
         client = docker_sdk.DockerClient(
             base_url=host_url,

--- a/backend/core/app/deployment/deployment_plugins/docker.py
+++ b/backend/core/app/deployment/deployment_plugins/docker.py
@@ -39,7 +39,14 @@ def _split_image_reference(image_reference: str) -> tuple[str, str | None]:
 def get_docker_client(host_system, timeout: int | None = None):
     if host_system.is_core_host():
         socket_path = os.getenv("DOCKER_SOCKET_PATH", "/var/run/docker.sock")
-        host_url = f"unix://{socket_path}"
+        if os.path.exists(socket_path):
+            host_url = f"unix://{socket_path}"
+        else:
+            LOGGER.warning(
+                f"Unix socket {socket_path} not found, falling back to TCP for core host"
+            )
+            host, docker_port = host_system.get_host_and_docker_port()
+            host_url = f"tcp://{host}:{docker_port}"
     else:
         host, docker_port = host_system.get_host_and_docker_port()
         host_url = f"tcp://{host}:{docker_port}"

--- a/backend/core/app/deployment/deployment_plugins/docker_compose_support/host_operations.py
+++ b/backend/core/app/deployment/deployment_plugins/docker_compose_support/host_operations.py
@@ -34,6 +34,9 @@ class ComposeHostOperations:
         self._get_core_url = get_core_url
 
     def get_docker_host_url(self, host_system) -> str:
+        if host_system.is_core_host():
+            socket_path = os.getenv("DOCKER_SOCKET_PATH", "/var/run/docker.sock")
+            return f"unix://{socket_path}"
         host_ip, docker_port = host_system.get_host_and_docker_port()
         return f"tcp://{host_ip}:{docker_port}"
 

--- a/backend/core/app/deployment/deployment_plugins/docker_compose_support/host_operations.py
+++ b/backend/core/app/deployment/deployment_plugins/docker_compose_support/host_operations.py
@@ -36,7 +36,8 @@ class ComposeHostOperations:
     def get_docker_host_url(self, host_system) -> str:
         if host_system.is_core_host():
             socket_path = os.getenv("DOCKER_SOCKET_PATH", "/var/run/docker.sock")
-            return f"unix://{socket_path}"
+            if os.path.exists(socket_path):
+                return f"unix://{socket_path}"
         host_ip, docker_port = host_system.get_host_and_docker_port()
         return f"tcp://{host_ip}:{docker_port}"
 

--- a/backend/core/app/models/docker_host_system.py
+++ b/backend/core/app/models/docker_host_system.py
@@ -656,7 +656,9 @@ class DockerHostSystem(Base):
     async def is_host_reachable(self, timeout: float = 2.0) -> bool:
         if self.is_core_host():
             socket_path = os.getenv("DOCKER_SOCKET_PATH", "/var/run/docker.sock")
-            return os.path.exists(socket_path)
+            if os.path.exists(socket_path):
+                return True
+            # socket absent – fall back to TCP probe
         host, port = self.get_host_and_docker_port()
         try:
             reader, writer = await asyncio.wait_for(

--- a/backend/core/app/models/docker_host_system.py
+++ b/backend/core/app/models/docker_host_system.py
@@ -654,6 +654,9 @@ class DockerHostSystem(Base):
         return DOCKER_HOST_STATUS.UNAVAILABLE.value
 
     async def is_host_reachable(self, timeout: float = 2.0) -> bool:
+        if self.is_core_host():
+            socket_path = os.getenv("DOCKER_SOCKET_PATH", "/var/run/docker.sock")
+            return os.path.exists(socket_path)
         host, port = self.get_host_and_docker_port()
         try:
             reader, writer = await asyncio.wait_for(

--- a/backend/core/app/test/deployment/test_cids.py
+++ b/backend/core/app/test/deployment/test_cids.py
@@ -303,6 +303,7 @@ async def test_split_deployment(
         host.id = host_id
         host.name = f"Host-{host_id}"
         host.host = "localhost" if host_id == 1 else "192.168.1.100"
+        host.is_core_host.return_value = host_id == 1
         host.get_host_and_docker_port.return_value = (host.host, 2375)
         return host
 

--- a/backend/core/app/test/deployment/test_compose_support.py
+++ b/backend/core/app/test/deployment/test_compose_support.py
@@ -349,7 +349,8 @@ async def test_spec_manager_write_deployment_files_writes_ruleset_and_runtime_co
     assert (tmp_path / "sensor.yaml").read_text() == "sensor-config"
 
 
-def test_get_docker_host_url_core_host_returns_unix_socket():
+@patch("os.path.exists", return_value=True)
+def test_get_docker_host_url_core_host_returns_unix_socket(mock_exists):
     host_operations = ComposeHostOperations(
         docker_client_cls=MagicMock(),
         docker_sdk_module=MagicMock(),
@@ -360,6 +361,23 @@ def test_get_docker_host_url_core_host_returns_unix_socket():
     host_system = SimpleNamespace(is_core_host=lambda: True)
     url = host_operations.get_docker_host_url(host_system)
     assert url.startswith("unix://")
+
+
+@patch("os.path.exists", return_value=False)
+def test_get_docker_host_url_core_host_falls_back_to_tcp_when_no_socket(mock_exists):
+    host_operations = ComposeHostOperations(
+        docker_client_cls=MagicMock(),
+        docker_sdk_module=MagicMock(),
+        ids_component_cls=MagicMock(),
+        logger=MagicMock(),
+        get_core_url=MagicMock(),
+    )
+    host_system = SimpleNamespace(
+        is_core_host=lambda: True,
+        get_host_and_docker_port=lambda: ("172.17.0.1", 2375),
+    )
+    url = host_operations.get_docker_host_url(host_system)
+    assert url == "tcp://172.17.0.1:2375"
 
 
 def test_get_docker_host_url_remote_host_returns_tcp():

--- a/backend/core/app/test/deployment/test_compose_support.py
+++ b/backend/core/app/test/deployment/test_compose_support.py
@@ -349,6 +349,35 @@ async def test_spec_manager_write_deployment_files_writes_ruleset_and_runtime_co
     assert (tmp_path / "sensor.yaml").read_text() == "sensor-config"
 
 
+def test_get_docker_host_url_core_host_returns_unix_socket():
+    host_operations = ComposeHostOperations(
+        docker_client_cls=MagicMock(),
+        docker_sdk_module=MagicMock(),
+        ids_component_cls=MagicMock(),
+        logger=MagicMock(),
+        get_core_url=MagicMock(),
+    )
+    host_system = SimpleNamespace(is_core_host=lambda: True)
+    url = host_operations.get_docker_host_url(host_system)
+    assert url.startswith("unix://")
+
+
+def test_get_docker_host_url_remote_host_returns_tcp():
+    host_operations = ComposeHostOperations(
+        docker_client_cls=MagicMock(),
+        docker_sdk_module=MagicMock(),
+        ids_component_cls=MagicMock(),
+        logger=MagicMock(),
+        get_core_url=MagicMock(),
+    )
+    host_system = SimpleNamespace(
+        is_core_host=lambda: False,
+        get_host_and_docker_port=lambda: ("10.0.0.5", 2376),
+    )
+    url = host_operations.get_docker_host_url(host_system)
+    assert url == "tcp://10.0.0.5:2376"
+
+
 def test_host_operations_copy_runtime_configs_blocking_uploads_archive(tmp_path):
     docker_sdk_module = MagicMock()
     host_docker = MagicMock()
@@ -368,7 +397,10 @@ def test_host_operations_copy_runtime_configs_blocking_uploads_archive(tmp_path)
     runtime_file = tmp_path / "sensor.yaml"
     runtime_file.write_text("content")
     deployment = SimpleNamespace(
-        host_system=SimpleNamespace(get_host_and_docker_port=lambda: ("127.0.0.1", 2375)),
+        host_system=SimpleNamespace(
+            get_host_and_docker_port=lambda: ("127.0.0.1", 2375),
+            is_core_host=lambda: True,
+        ),
         runtime_config_files={str(runtime_file): MagicMock()},
         paths=SimpleNamespace(work_dir="/tmp/bicep_cids_1_localhost"),
     )
@@ -424,6 +456,7 @@ async def test_host_operations_start_project_registers_components_and_scales():
         host_system=SimpleNamespace(
             name="Remote",
             id=5,
+            is_core_host=lambda: False,
             get_host_and_docker_port=lambda: ("10.0.0.5", 2375),
         ),
         paths=SimpleNamespace(
@@ -511,6 +544,7 @@ async def test_host_operations_start_project_redeploys_only_requested_services()
         host_system=SimpleNamespace(
             name="Remote",
             id=5,
+            is_core_host=lambda: False,
             get_host_and_docker_port=lambda: ("10.0.0.5", 2375),
         ),
         paths=SimpleNamespace(
@@ -575,6 +609,7 @@ async def test_host_operations_start_project_wraps_compose_errors():
     deployment = SimpleNamespace(
         host_system=SimpleNamespace(
             name="Remote",
+            is_core_host=lambda: False,
             get_host_and_docker_port=lambda: ("10.0.0.5", 2375),
         ),
         paths=SimpleNamespace(
@@ -633,6 +668,7 @@ def test_host_operations_teardown_remote_project_blocking_falls_back_to_containe
     result = host_operations._teardown_remote_project_blocking(
         host_system=SimpleNamespace(
             name="Remote",
+            is_core_host=lambda: False,
             get_host_and_docker_port=lambda: ("10.0.0.5", 2375),
         ),
         components=[SimpleNamespace(name="sensor")],

--- a/backend/core/app/test/deployment/test_docker.py
+++ b/backend/core/app/test/deployment/test_docker.py
@@ -53,7 +53,8 @@ def mock_container():
     return MagicMock()
 
 @patch("docker.DockerClient")
-def test_get_docker_client_core_host_uses_socket(mock_docker_client, mock_client, mock_host_system):
+@patch("os.path.exists", return_value=True)
+def test_get_docker_client_core_host_uses_socket(mock_exists, mock_docker_client, mock_client, mock_host_system):
     mock_docker_client.return_value = mock_client
     mock_host_system.is_core_host.return_value = True
 
@@ -62,6 +63,20 @@ def test_get_docker_client_core_host_uses_socket(mock_docker_client, mock_client
     assert client == mock_client
     called_url = mock_docker_client.call_args[1]["base_url"]
     assert called_url.startswith("unix://")
+
+
+@patch("docker.DockerClient")
+@patch("os.path.exists", return_value=False)
+def test_get_docker_client_core_host_falls_back_to_tcp_when_no_socket(mock_exists, mock_docker_client, mock_client, mock_host_system):
+    mock_docker_client.return_value = mock_client
+    mock_host_system.is_core_host.return_value = True
+    mock_host_system.get_host_and_docker_port.return_value = ("172.17.0.1", 2375)
+
+    client = get_docker_client(mock_host_system)
+
+    assert client == mock_client
+    called_url = mock_docker_client.call_args[1]["base_url"]
+    assert called_url == "tcp://172.17.0.1:2375"
 
 
 @patch("docker.DockerClient")

--- a/backend/core/app/test/deployment/test_docker.py
+++ b/backend/core/app/test/deployment/test_docker.py
@@ -53,20 +53,28 @@ def mock_container():
     return MagicMock()
 
 @patch("docker.DockerClient")
-@patch("app.utils.get_core_host_ip")
-def test_get_docker_client(mock_get_core_host, mock_docker_client, mock_client, mock_host_system):
-    mock_get_core_host.return_value = "127.0.0.1"
+def test_get_docker_client_core_host_uses_socket(mock_docker_client, mock_client, mock_host_system):
     mock_docker_client.return_value = mock_client
-
-    mock_host_system.name = "CoreHost"
-    mock_host_system.host = "localhost"
-    mock_host_system.docker_port = 2375
-    get_host_and_docker_port_mock = MagicMock()
-    get_host_and_docker_port_mock.return_value = (mock_host_system.host, mock_host_system.docker_port)
-    mock_host_system.get_host_and_docker_port = get_host_and_docker_port_mock
+    mock_host_system.is_core_host.return_value = True
 
     client = get_docker_client(mock_host_system)
+
     assert client == mock_client
+    called_url = mock_docker_client.call_args[1]["base_url"]
+    assert called_url.startswith("unix://")
+
+
+@patch("docker.DockerClient")
+def test_get_docker_client_remote_host_uses_tcp(mock_docker_client, mock_client, mock_host_system):
+    mock_docker_client.return_value = mock_client
+    mock_host_system.is_core_host.return_value = False
+    mock_host_system.get_host_and_docker_port.return_value = ("10.0.0.5", 2376)
+
+    client = get_docker_client(mock_host_system)
+
+    assert client == mock_client
+    called_url = mock_docker_client.call_args[1]["base_url"]
+    assert called_url == "tcp://10.0.0.5:2376"
 
 @pytest.mark.asyncio
 @patch("app.deployment.deployment_plugins.docker.get_docker_client")
@@ -109,6 +117,7 @@ async def test_remove_docker_container(mock_get_host_and_port,mock_docker_client
     mock_get_host_and_port.return_value = ("localhost", 2375)
     mock_host_system = MagicMock()
     mock_host_system.get_host_and_docker_port = mock_get_host_and_port
+    mock_host_system.is_core_host.return_value = False
     mock_ids_container.host_system = mock_host_system
 
     await remove_docker_container(mock_ids_container)

--- a/backend/core/app/test/models/test_docker_host_system.py
+++ b/backend/core/app/test/models/test_docker_host_system.py
@@ -590,6 +590,22 @@ async def test_check_metric_service_health_schedules_background_deploy_when_miss
 
 
 @pytest.mark.asyncio
+async def test_is_host_reachable_core_host_socket_exists(core_host: DockerHostSystem):
+    """For core host, should return True when the socket file exists."""
+    with patch("os.path.exists", return_value=True):
+        result = await core_host.is_host_reachable()
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_is_host_reachable_core_host_socket_missing(core_host: DockerHostSystem):
+    """For core host, should return False when the socket file is absent."""
+    with patch("os.path.exists", return_value=False):
+        result = await core_host.is_host_reachable()
+    assert result is False
+
+
+@pytest.mark.asyncio
 async def test_is_host_reachable_success(remote_host: DockerHostSystem):
     """When TCP connection succeeds, should return True."""
     mock_writer = MagicMock()

--- a/backend/core/app/test/models/test_docker_host_system.py
+++ b/backend/core/app/test/models/test_docker_host_system.py
@@ -598,10 +598,26 @@ async def test_is_host_reachable_core_host_socket_exists(core_host: DockerHostSy
 
 
 @pytest.mark.asyncio
-async def test_is_host_reachable_core_host_socket_missing(core_host: DockerHostSystem):
-    """For core host, should return False when the socket file is absent."""
+async def test_is_host_reachable_core_host_socket_missing_tcp_reachable(core_host: DockerHostSystem):
+    """For core host with no socket, should fall back to TCP and return True when reachable."""
+    mock_writer = MagicMock()
+    mock_writer.close = MagicMock()
+    mock_writer.wait_closed = AsyncMock()
     with patch("os.path.exists", return_value=False):
-        result = await core_host.is_host_reachable()
+        with patch("app.models.docker_host_system.get_core_host_ip", return_value="172.17.0.1"):
+            with patch("asyncio.wait_for", new_callable=AsyncMock) as mock_wait_for:
+                mock_wait_for.return_value = (MagicMock(), mock_writer)
+                result = await core_host.is_host_reachable()
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_is_host_reachable_core_host_socket_missing_tcp_unreachable(core_host: DockerHostSystem):
+    """For core host with no socket, should fall back to TCP and return False when unreachable."""
+    with patch("os.path.exists", return_value=False):
+        with patch("app.models.docker_host_system.get_core_host_ip", return_value="172.17.0.1"):
+            with patch("asyncio.wait_for", side_effect=ConnectionRefusedError):
+                result = await core_host.is_host_reachable()
     assert result is False
 
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,6 +41,7 @@ services:
       context: ./backend/core
     volumes:
       - ./backend/core/app:/opt/app
+      - /var/run/docker.sock:/var/run/docker.sock
     command: fastapi dev main.py --host 0.0.0.0 --port 8000
     depends_on:
       database:

--- a/docs/usage/start.rst
+++ b/docs/usage/start.rst
@@ -38,52 +38,13 @@ If Production mode has not been enabled in such a setup, the frontend tries to r
 
 Core Configuration
 ------------------
-The docker daemon on the Core machine needs to be configured appropriately, so that containers can be deployed by it. For this you need to adjust the docker config in ``/etc/systemd/system/docker.service.d/docker.conf`` add the following lines:
+For a single-node setup, no special Docker daemon configuration is required. BICEP's core service connects to the Docker daemon through the Unix socket (``/var/run/docker.sock``), which is mounted into the core container by the ``docker-compose.yaml``. This means the daemon is never exposed over the network.
 
-.. code-block:: bash
-
-    [Service]
-    ExecStart=
-    ExecStart=/usr/bin/dockerd -H tcp://172.22.0.1:2375 -H unix:///var/run/docker.sock --tls=false
-
-This will allow external services like the core to access the Docker daemon remotely. Afterwards, run:
-
-.. code-block:: bash
-
-    sudo systemctl daemon-reload
-    sudo systemctl restart docker.service
-
-
+.. note::
+    If you need to use a custom socket path, set the ``DOCKER_SOCKET_PATH`` environment variable in the core service.
 
 .. warning::
-    Please note that this allows connections to the docker daemon only by the local machine via the BICEP network. If you change the network as configured in the ``docker-compose.yaml`` then you will need to adjust the daemon accordingly.
     If not configured correctly you will not be able to start any IDS container or the metric service.
-
-
-Troubleshooting
-~~~~~~~~~~~~~~~~
-
-**My Docker service is not starting after changing the configuration**
-
-The reason can be twofold: On newer versions of docker >29, the docker daemon needs to be started with the ``--tls=false`` flag to allow unencrypted connections or the daemon needs to be secured properly https://docs.docker.com/engine/security/protect-access/.
-Alternatively, the docker service might refuse to start because it can't bind to the 172.22.0.1 IP address. Two mitigate this either (before changing the daemon configuration), start the BICEP application, to create the needed interface, or run the following:
-
-.. code-block:: bash
-
-    sudo ip link add docker-dummy0 type dummy
-    sudo ip addr add 172.22.0.1/32 dev docker-dummy0
-    sudo ip link set docker-dummy0 up
-    sudo systemctl restart docker 
-    sudo ip link delete docker-dummy0
-
-This will create a temporary dummy interface with the required IP address, so that the docker daemon can start and create the BICEP network. After the network is created, the dummy interface can be removed again.
-
-
-**After starting the application, the docker host is not becoming available**
-
-In this case check the logs of the core. Either, your docker daemon is not configured with the proper IP bind address, or a firewall setup on your host like ufw is blocking the connection. To bypass the latter, you will need to add a rule to allow incoming connections on port 2375.
-
-
 
 .. _distributed_setup:
 
@@ -91,9 +52,44 @@ Distributed Setup
 -----------------
 
 You may want a distributed setup to host the application on one machine and benchmark IDS' on another node, to avoid performance intereference. 
-For this, the remote machine needs to have the docker daemon configured like the Core host, with some slight differences:
+For this, the remote machine's Docker daemon needs to be reachable over TCP from the machine running BICEP.
 
-In your docker config in ``/etc/systemd/system/docker.service.d/docker.conf`` add the following lines:
+.. warning::
+    Exposing the Docker daemon over an unencrypted and unauthenticated TCP connection is a significant security risk, as it grants root-equivalent access to the remote machine. **We strongly recommend securing the daemon with TLS mutual authentication (mTLS)** before exposing it over the network. See https://docs.docker.com/engine/security/protect-access/ for the full guide.
+
+**Recommended: Secure the daemon with TLS**
+
+Generate a CA, server certificate and client certificate on the remote node, then configure ``/etc/systemd/system/docker.service.d/docker.conf``:
+
+.. code-block:: bash
+
+    [Service]
+    ExecStart=
+    ExecStart=/usr/bin/dockerd -H tcp://x.x.x.x:2375 -H unix:///var/run/docker.sock \
+        --tlsverify --tlscacert=/etc/docker/certs/ca.pem \
+        --tlscert=/etc/docker/certs/server-cert.pem \
+        --tlskey=/etc/docker/certs/server-key.pem
+
+Then place the corresponding client certificate, key and CA in a directory accessible to the core container (e.g. ``/etc/docker/certs/client/``) and mount it:
+
+.. code-block:: yaml
+
+    # docker-compose.yaml — core service
+    volumes:
+      - /etc/docker/certs/client:/etc/docker/client-certs:ro
+
+Configure the core to use the client certs by setting the following environment variables on the core service:
+
+.. code-block:: yaml
+
+    environment:
+      - DOCKER_TLS_CERTDIR=/etc/docker/client-certs
+
+**Minimum (insecure) alternative**
+
+If TLS is not possible, restrict the bind address to only the IP that the BICEP machine can reach and use firewall rules to allow port 2375 only from the BICEP host's IP.
+
+In ``/etc/systemd/system/docker.service.d/docker.conf``:
 
 .. code-block:: bash
 
@@ -101,12 +97,10 @@ In your docker config in ``/etc/systemd/system/docker.service.d/docker.conf`` ad
     ExecStart=
     ExecStart=/usr/bin/dockerd -H tcp://x.x.x.x:2375 -H unix:///var/run/docker.sock --tls=false
 
-Make sure that you expose a remotely available IP address that the other machine hosting the BICEP application can reach! 
+Make sure that you expose a remotely available IP address that the other machine hosting the BICEP application can reach!
 
 .. warning::
-    0.0.0.0 allows access from any IP. You should make sure to only allow trusted IPs to access the docker daemon remotely. We refer to https://docs.docker.com/engine/daemon/remote-access/ and https://docs.docker.com/engine/security/protect-access/ for a secure Docker daemon connection.
-
-
+    Never bind to ``0.0.0.0`` without firewall restrictions. Doing so grants unauthenticated root-level access to your machine to anyone who can reach that port.
 
 Afterwards run:
 
@@ -115,8 +109,8 @@ Afterwards run:
     sudo systemctl daemon-reload
     sudo systemctl restart docker.service
 
-This refreshs the daemon for docker. You can now use the web GUI to add the new node to the framework by following the instructions on the `Docker Hosts` tab. 
-per default, the localhost (the machine where the framework is running), is already added and can be used. Any other node needs to be added via the GUI or DB.
+This refreshes the daemon for Docker. You can now use the web GUI to add the new node to the framework by following the instructions on the `Docker Hosts` tab. 
+Per default, the localhost (the machine where the framework is running), is already added and can be used. Any other node needs to be added via the GUI or DB.
 
 .. _mac_support:
 


### PR DESCRIPTION
### Problem

The single-node setup required exposing the Docker daemon over unauthenticated TCP:

```
/usr/bin/dockerd -H tcp://172.22.0.1:2375
```

Any process on the host could control Docker without credentials.

### Solution

Mount the Docker Unix socket into the core container and use it directly. The TCP listener is no longer needed for single-node operation.

**Changes:**

| File | Change |
|---|---|
| `docker-compose.yaml` | Mount docker.sock into the `core` service |
| `docker.py` - `get_docker_client` | Use `unix:///var/run/docker.sock` for the core host; keep TCP for remote hosts |
| `host_operations.py` - `get_docker_host_url` | Same branch logic for docker-compose operations |
| `docker_host_system.py` - `is_host_reachable` | Check socket file existence instead of TCP-connecting to port 2375 |
| `start.rst` | Rewrite single-node section (no daemon flag needed); add TLS guidance for remote/distributed hosts |

**Fallback behaviour:** If the socket file is absent at runtime (e.g. bind-mount not configured, custom path, Podman or general weird system configuration), all three entry points automatically fall back to TCP. The socket path is configurable via the `DOCKER_SOCKET_PATH` environment variable.

### Testing

- All 78 unit tests pass, including new tests for the socket path, the socket->TCP fallback, and the TCP reachability check.

Additionally, manual testing on **Arch Linux, kernel 7.0.3-arch1-2, x86\_64, Docker 29.4.2** of the single-node setup confirms:
- `Docker Hosts` tab shows **Available** for Core-server immediately on startup without ever running `dockerd -H tcp://`.
- Creating a default **Suricata** container and running the `sample-data` dataset on it completes successfully end-to-end.

**Windows / macOS:** Per `Supported Systems` in README.md, not a primary concern. Therefore also not tested directly. However, both platforms run Linux containers inside a Linux VM managed by Docker Desktop, which exposes the Docker socket to containers at the same standard path (`/var/run/docker.sock`) transparently. The volume mount `- /var/run/docker.sock:/var/run/docker.sock` is a well-established cross-platform pattern (used by Portainer, Watchtower, etc.). In the unlikely event the socket is absent or remapped, the TCP fallback ensures the setup continues to work.