### PR TITLE
fix: add persistent volume for MariaDB data

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,6 +78,8 @@ services:
       - MARIADB_ROOT_PASSWORD=root
     ports:
       - 3306:3306
+    volumes:
+      - bicep_db_data:/var/lib/mysql
     healthcheck:
       test: ["CMD-SHELL", "mariadb -uroot -p$${MARIADB_ROOT_PASSWORD} -e 'SELECT 1'"]
       start_period: 10s
@@ -108,3 +110,6 @@ networks:
       config:
         - subnet: 172.22.0.0/16
           gateway: 172.22.0.1
+
+volumes:
+  bicep_db_data:


### PR DESCRIPTION
### Problem

IDS tools added via the UI (IDS Tools tab) were lost on every container restart. The `database` service had no volume mount, so MariaDB wrote all data to the container's ephemeral filesystem. On restart, the container was re-initialized from `bicep.sql`, restoring only the default entries. This seemed unintuitive and caused confusion, as users expected their added tools and host systems to persist.

### Fix

Adds a named Docker volume `bicep_db_data` mounted at `/var/lib/mysql` in the `database` service. This ensures all database writes (user-added IDS tools, host systems, etc.)  persist across container restarts.

### Migration

No schema changes. On first `docker compose up` after this change, the named volume is created automatically. Existing deployments with no prior volume will be re-initialized from `bicep.sql` once, then persist normally from that point on.

If someone really wants to clean up their database, they can still intentionally remove the named volume with `docker volume rm bicep_db_data`, which will cause a fresh initialization on next startup.